### PR TITLE
Fixed exception with prs command

### DIFF
--- a/plugins/prs.py
+++ b/plugins/prs.py
@@ -67,4 +67,4 @@ def prs(bot, event, *args):
             )
         )
 
-    bot.send_message_parsed(event.conv, segments)
+    bot.send_message_segments(event.conv, segments)


### PR DESCRIPTION
Replaced `bot.send_message_parsed()` with `bot.send_message_segments()` to fix exception.
